### PR TITLE
Add optional allocation counter

### DIFF
--- a/py/gc.c
+++ b/py/gc.c
@@ -35,7 +35,7 @@
 #if MICROPY_ENABLE_GC
 
 #if MICROPY_TREZOR_MEMPERF
-uint64_t alloc_count = 0;
+mp_uint_t alloc_count = 0;
 #endif
 
 #if MICROPY_DEBUG_VERBOSE // print debugging info

--- a/py/gc.c
+++ b/py/gc.c
@@ -34,6 +34,10 @@
 
 #if MICROPY_ENABLE_GC
 
+#if MICROPY_TREZOR_MEMPERF
+uint64_t alloc_count = 0;
+#endif
+
 #if MICROPY_DEBUG_VERBOSE // print debugging info
 #define DEBUG_PRINT (1)
 #define DEBUG_printf DEBUG_printf
@@ -554,6 +558,10 @@ found:
 
     #if EXTENSIVE_HEAP_PROFILING
     gc_dump_alloc_table();
+    #endif
+
+    #if MICROPY_TREZOR_MEMPERF
+    ++alloc_count;
     #endif
 
     return ret_ptr;

--- a/py/gc.h
+++ b/py/gc.h
@@ -72,7 +72,7 @@ void gc_dump_info(void);
 void gc_dump_alloc_table(void);
 
 #if MICROPY_TREZOR_MEMPERF
-extern uint64_t alloc_count;
+extern mp_uint_t alloc_count;
 #endif
 
 #endif // MICROPY_INCLUDED_PY_GC_H

--- a/py/gc.h
+++ b/py/gc.h
@@ -71,4 +71,8 @@ void gc_info(gc_info_t *info);
 void gc_dump_info(void);
 void gc_dump_alloc_table(void);
 
+#if MICROPY_TREZOR_MEMPERF
+extern uint64_t alloc_count;
+#endif
+
 #endif // MICROPY_INCLUDED_PY_GC_H

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -166,7 +166,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_2(mp_micropython_schedule_obj, mp_micropython_sch
 
 #if MICROPY_TREZOR_MEMPERF
 STATIC mp_obj_t mp_micropython_alloc_count(void) {
-    return mp_obj_new_int(alloc_count);
+    return mp_obj_new_int_from_uint(alloc_count);
 }
 STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_alloc_count_obj, mp_micropython_alloc_count);
 #endif

--- a/py/modmicropython.c
+++ b/py/modmicropython.c
@@ -164,6 +164,13 @@ STATIC mp_obj_t mp_micropython_schedule(mp_obj_t function, mp_obj_t arg) {
 STATIC MP_DEFINE_CONST_FUN_OBJ_2(mp_micropython_schedule_obj, mp_micropython_schedule);
 #endif
 
+#if MICROPY_TREZOR_MEMPERF
+STATIC mp_obj_t mp_micropython_alloc_count(void) {
+    return mp_obj_new_int(alloc_count);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(mp_micropython_alloc_count_obj, mp_micropython_alloc_count);
+#endif
+
 STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_micropython) },
     { MP_ROM_QSTR(MP_QSTR_const), MP_ROM_PTR(&mp_identity_obj) },
@@ -200,6 +207,9 @@ STATIC const mp_rom_map_elem_t mp_module_micropython_globals_table[] = {
     #endif
     #if MICROPY_ENABLE_SCHEDULER
     { MP_ROM_QSTR(MP_QSTR_schedule), MP_ROM_PTR(&mp_micropython_schedule_obj) },
+    #endif
+    #if MICROPY_TREZOR_MEMPERF
+    { MP_ROM_QSTR(MP_QSTR_alloc_count), MP_ROM_PTR(&mp_micropython_alloc_count_obj) },
     #endif
 };
 

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -432,6 +432,11 @@
 #define MICROPY_MEM_STATS (0)
 #endif
 
+// Whether to count GC allocations
+#ifndef MICROPY_TREZOR_MEMPERF
+#define MICROPY_TREZOR_MEMPERF (0)
+#endif
+
 // The mp_print_t printer used for debugging output
 #ifndef MICROPY_DEBUG_PRINTER
 #define MICROPY_DEBUG_PRINTER (&mp_plat_print)


### PR DESCRIPTION
Add counter of allocations for tracking memory usage - see trezor/trezor-firmware#1324 for more information. The feature is off by default and has to be explicitly enabled at build time.