### PR TITLE
Optional print() redirection to RTT or SystemView

### DIFF
--- a/py/modbuiltins.c
+++ b/py/modbuiltins.c
@@ -419,17 +419,19 @@ STATIC mp_obj_t mp_builtin_print(size_t n_args, const mp_obj_t *pos_args, mp_map
     mp_print_t print = {MP_OBJ_TO_PTR(u.args[ARG_file].u_obj), mp_stream_write_adaptor};
     #endif
 
+    #if !SYSTEMVIEW_DEST_SYSTEMVIEW
     // extract the objects first because we are going to use the other part of the union
     mp_obj_t sep = u.args[ARG_sep].u_obj;
     mp_obj_t end = u.args[ARG_end].u_obj;
     const char *sep_data = mp_obj_str_get_data(sep, &u.len[0]);
     const char *end_data = mp_obj_str_get_data(end, &u.len[1]);
+    #endif
 
     for (size_t i = 0; i < n_args; i++) {
         if (i > 0) {
             #if MICROPY_PY_IO && MICROPY_PY_SYS_STDFILES
             mp_stream_write_adaptor(print.data, sep_data, u.len[0]);
-            #else
+            #elif !SYSTEMVIEW_DEST_SYSTEMVIEW
             mp_print_strn(&mp_plat_print, sep_data, u.len[0], 0, 0, 0);
             #endif
         }
@@ -441,7 +443,7 @@ STATIC mp_obj_t mp_builtin_print(size_t n_args, const mp_obj_t *pos_args, mp_map
     }
     #if MICROPY_PY_IO && MICROPY_PY_SYS_STDFILES
     mp_stream_write_adaptor(print.data, end_data, u.len[1]);
-    #else
+    #elif !SYSTEMVIEW_DEST_SYSTEMVIEW
     mp_print_strn(&mp_plat_print, end_data, u.len[1], 0, 0, 0);
     #endif
     return mp_const_none;

--- a/py/mpprint.c
+++ b/py/mpprint.c
@@ -43,6 +43,10 @@
 static const char pad_spaces[] = "                ";
 static const char pad_zeroes[] = "0000000000000000";
 
+#ifdef SYSTEM_VIEW
+size_t segger_print(const char* str, size_t len);
+#endif
+
 STATIC void plat_print_strn(void *env, const char *str, size_t len) {
     (void)env;
     MP_PLAT_PRINT_STRN(str, len);


### PR DESCRIPTION
When building from toplevel trezor-firmware, allows to set `SYSTEM_VIEW` option to redirect print through memory buffers that are retrieved by HW debug adapter via SWD/JTAG.