### PR TITLE
add new Trezor features

### DIFF
--- a/py/modgc.c
+++ b/py/modgc.c
@@ -76,6 +76,17 @@ STATIC mp_obj_t gc_mem_alloc(void) {
 }
 MP_DEFINE_CONST_FUN_OBJ_0(gc_mem_alloc_obj, gc_mem_alloc);
 
+// mem_frag(): return the memory fragmentation
+STATIC mp_obj_t gc_mem_frag(void) {
+    gc_info_t info;
+    gc_info(&info);
+    size_t max_free_block = info.max_free * MICROPY_BYTES_PER_GC_BLOCK;
+    size_t total_free_space = info.free;
+    float frag = 1.0f - ((float)max_free_block / (float)total_free_space);
+    return mp_obj_new_float_from_f(frag);
+}
+STATIC MP_DEFINE_CONST_FUN_OBJ_0(gc_mem_frag_obj, gc_mem_frag);
+
 #if MICROPY_GC_ALLOC_THRESHOLD
 STATIC mp_obj_t gc_threshold(size_t n_args, const mp_obj_t *args) {
     if (n_args == 0) {
@@ -103,6 +114,7 @@ STATIC const mp_rom_map_elem_t mp_module_gc_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR_isenabled), MP_ROM_PTR(&gc_isenabled_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_free), MP_ROM_PTR(&gc_mem_free_obj) },
     { MP_ROM_QSTR(MP_QSTR_mem_alloc), MP_ROM_PTR(&gc_mem_alloc_obj) },
+    { MP_ROM_QSTR(MP_QSTR_mem_frag), MP_ROM_PTR(&gc_mem_frag_obj) },
     #if MICROPY_GC_ALLOC_THRESHOLD
     { MP_ROM_QSTR(MP_QSTR_threshold), MP_ROM_PTR(&gc_threshold_obj) },
     #endif

--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -229,6 +229,11 @@
 #define MICROPY_MODULE_DICT_SIZE (1)
 #endif
 
+// Initial size of sys.modules dict
+#ifndef MICROPY_LOADED_MODULES_DICT_SIZE
+#define MICROPY_LOADED_MODULES_DICT_SIZE (3)
+#endif
+
 // Whether realloc/free should be passed allocated memory region size
 // You must enable this if MICROPY_MEM_STATS is enabled
 #ifndef MICROPY_MALLOC_USES_ALLOCATED_SIZE

--- a/py/objboundmeth.c
+++ b/py/objboundmeth.c
@@ -95,7 +95,10 @@ STATIC void bound_meth_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
 }
 #endif
 
-STATIC const mp_obj_type_t mp_type_bound_meth = {
+#ifndef TREZOR_EMULATOR
+STATIC
+#endif
+const mp_obj_type_t mp_type_bound_meth = {
     { &mp_type_type },
     .name = MP_QSTR_bound_method,
     #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED

--- a/py/objcell.c
+++ b/py/objcell.c
@@ -55,7 +55,10 @@ STATIC void cell_print(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t k
 }
 #endif
 
-STATIC const mp_obj_type_t mp_type_cell = {
+#ifndef TREZOR_EMULATOR
+STATIC
+#endif
+const mp_obj_type_t mp_type_cell = {
     { &mp_type_type },
     .name = MP_QSTR_, // cell representation is just value in < >
     #if MICROPY_ERROR_REPORTING == MICROPY_ERROR_REPORTING_DETAILED

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -91,7 +91,7 @@ void mp_init(void) {
     #endif
 
     // init global module dict
-    mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), 3);
+    mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), MICROPY_LOADED_MODULES_DICT_SIZE);
 
     // initialise the __main__ module
     mp_obj_dict_init(&MP_STATE_VM(dict_main), 1);


### PR DESCRIPTION
the important bit here is 232f83d : this makes the preallocated size of `sys.modules` configurable so that we can set it to 150

the other two commits are niceties for memory usage debugging, there will be an accompanying PR to trezor-firmware that makes use of it