### PR TITLE
uzlib(trezor): partially optimize decompression for speed

### DIFF
--- a/lib/uzlib/tinflate.c
+++ b/lib/uzlib/tinflate.c
@@ -549,6 +549,7 @@ void uzlib_uncompress_init(TINF_DATA *d, void *dict, unsigned int dictLen)
 }
 
 /* inflate next output bytes from compressed stream */
+__attribute__((optimize("-O3")))
 int uzlib_uncompress(TINF_DATA *d)
 {
     do {


### PR DESCRIPTION
at the cost of about 100B flash space, this increases decompression speed (the speed improvement depends on several factors, but improvements in range of 10-30% have been observed