### PR TITLE
uzlib(trezor): add user context for source callback

### DIFF
--- a/lib/uzlib/uzlib.h
+++ b/lib/uzlib/uzlib.h
@@ -93,6 +93,9 @@ struct uzlib_uncomp {
        besides returning the next byte, it may also update source and
        source_limit fields, thus allowing for buffered operation. */
     int (*source_read_cb)(struct uzlib_uncomp *uncomp);
+    /* Source callback context parameter not used by the library itself.
+       User can use it to pass additional data to source_read_cb. */
+    void *source_read_cb_context;
 
     unsigned int tag;
     unsigned int bitcount;


### PR DESCRIPTION
This tiny PR adds one extra field to `uzlib_uncomp` to enable the passing of a user context parameter to `source_read_cb`. This is needed by the uzlib wrapper in Rust that provides stream-like source reading.

The change doesn't break the uzlib API.