### PR TITLE
py/runtime: make `__main__` preallocate to a configurable size

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -259,6 +259,11 @@
 #define MICROPY_LOADED_MODULES_DICT_SIZE (3)
 #endif
 
+// Initial size of __main__ dict
+#ifndef MICROPY_MAIN_DICT_SIZE
+#define MICROPY_MAIN_DICT_SIZE (1)
+#endif
+
 // Whether realloc/free should be passed allocated memory region size
 // You must enable this if MICROPY_MEM_STATS is enabled
 #ifndef MICROPY_MALLOC_USES_ALLOCATED_SIZE

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -105,7 +105,7 @@ void mp_init(void) {
     mp_obj_dict_init(&MP_STATE_VM(mp_loaded_modules_dict), MICROPY_LOADED_MODULES_DICT_SIZE);
 
     // initialise the __main__ module
-    mp_obj_dict_init(&MP_STATE_VM(dict_main), 1);
+    mp_obj_dict_init(&MP_STATE_VM(dict_main), MICROPY_MAIN_DICT_SIZE);
     mp_obj_dict_store(MP_OBJ_FROM_PTR(&MP_STATE_VM(dict_main)), MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR___main__));
 
     // locals = globals for outer module (see Objects/frameobject.c/PyFrame_New())


### PR DESCRIPTION
Similar to https://github.com/micropython/micropython/pull/7113.