### PR TITLE
py/map: allow disabling reallocation for specific dicts

### DIFF
--- a/py/map.c
+++ b/py/map.c
@@ -98,6 +98,7 @@ void mp_map_init(mp_map_t *map, size_t n) {
     map->all_keys_are_qstrs = 1;
     map->is_fixed = 0;
     map->is_ordered = 0;
+    map->no_realloc = 0;
 }
 
 void mp_map_init_fixed_table(mp_map_t *map, size_t n, const mp_obj_t *table) {
@@ -106,6 +107,7 @@ void mp_map_init_fixed_table(mp_map_t *map, size_t n, const mp_obj_t *table) {
     map->all_keys_are_qstrs = 1;
     map->is_fixed = 1;
     map->is_ordered = 1;
+    map->no_realloc = 1;
     map->table = (mp_map_elem_t *)table;
 }
 
@@ -129,6 +131,9 @@ void mp_map_clear(mp_map_t *map) {
 }
 
 STATIC void mp_map_rehash(mp_map_t *map) {
+    if (map->no_realloc) {
+        mp_raise_msg(&mp_type_MemoryError, "Cannot reallocate map");
+    }
     size_t old_alloc = map->alloc;
     size_t new_alloc = get_hash_alloc_greater_or_equal_to(map->alloc + 1);
     DEBUG_printf("mp_map_rehash(%p): " UINT_FMT " -> " UINT_FMT "\n", map, old_alloc, new_alloc);

--- a/py/obj.h
+++ b/py/obj.h
@@ -440,7 +440,8 @@ typedef struct _mp_map_t {
     size_t all_keys_are_qstrs : 1;
     size_t is_fixed : 1;    // if set, table is fixed/read-only and can't be modified
     size_t is_ordered : 1;  // if set, table is an ordered array, not a hash map
-    size_t used : (8 * sizeof(size_t) - 3);
+    size_t no_realloc : 1;  // if set, table may not be reallocated (only relevant if `is_fixed` == 0)
+    size_t used : (8 * sizeof(size_t) - 4);
     size_t alloc;
     mp_map_elem_t *table;
 } mp_map_t;

--- a/py/objdict.c
+++ b/py/objdict.c
@@ -254,6 +254,7 @@ mp_obj_t mp_obj_dict_copy(mp_obj_t self_in) {
     other->map.all_keys_are_qstrs = self->map.all_keys_are_qstrs;
     other->map.is_fixed = 0;
     other->map.is_ordered = self->map.is_ordered;
+    other->map.no_realloc = self->map.no_realloc;
     memcpy(other->map.table, self->map.table, self->map.alloc * sizeof(mp_map_elem_t));
     return other_out;
 }


### PR DESCRIPTION
Also, enable this feature for `__main__` and `sys.modules`.