### PR TITLE
py/misc: zero stack memory allocated by `VSTR_FIXED`

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -177,7 +177,7 @@ typedef struct _vstr_t {
 } vstr_t;
 
 // convenience macro to declare a vstr with a fixed size buffer on the stack
-#define VSTR_FIXED(vstr, alloc) vstr_t vstr; char vstr##_buf[(alloc)]; vstr_init_fixed_buf(&vstr, (alloc), vstr##_buf);
+#define VSTR_FIXED(vstr, alloc) vstr_t vstr; char vstr##_buf[(alloc)] = {0}; vstr_init_fixed_buf(&vstr, (alloc), vstr##_buf);
 
 void vstr_init(vstr_t *vstr, size_t alloc);
 void vstr_init_len(vstr_t *vstr, size_t len);


### PR DESCRIPTION
Otherwise, it may result in `gc_helper_collect_regs_and_stack()` false-positives.