### PR TITLE
Revert "tools/mpy-tool.py: Allow skipping files from freezing"

### DIFF
--- a/tools/mpy-tool.py
+++ b/tools/mpy-tool.py
@@ -1743,7 +1743,6 @@ def main():
         "-d", "--disassemble", action="store_true", help="output disassembled contents of files"
     )
     cmd_parser.add_argument("-f", "--freeze", action="store_true", help="freeze files")
-    cmd_parser.add_argument("--skip-freeze", nargs="*", default=(), help="skip this file from freezing (but collect its qstrs)")
     cmd_parser.add_argument(
         "--merge", action="store_true", help="merge multiple .mpy files into one"
     )
@@ -1804,11 +1803,6 @@ def main():
 
     if args.freeze:
         try:
-            skip_freeze = set(args.skip_freeze)
-            compiled_modules = [
-                cm for cm in compiled_modules
-                if cm.source_file.str not in skip_freeze
-            ]
             freeze_mpy(base_qstrs, compiled_modules)
         except FreezeError as er:
             print(er, file=sys.stderr)


### PR DESCRIPTION
This reverts commit 6bdefd147256d6a72827ac6225fc5e36bd92a801, following https://github.com/trezor/trezor-firmware/pull/4889.