### PR TITLE
Fix compilation with GCC 14

### DIFF
--- a/py/nlraarch64.c
+++ b/py/nlraarch64.c
@@ -74,7 +74,7 @@ NORETURN void nlr_jump(void *val) {
         "ret                     \n"
         :
         : "r" (top)
-        :
+        : "memory"
         );
 
     MP_UNREACHABLE

--- a/py/nlrthumb.c
+++ b/py/nlrthumb.c
@@ -132,7 +132,7 @@ NORETURN void nlr_jump(void *val) {
         "bx     lr                  \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/nlrx64.c
+++ b/py/nlrx64.c
@@ -105,7 +105,7 @@ NORETURN void nlr_jump(void *val) {
         "ret                        \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/nlrx86.c
+++ b/py/nlrx86.c
@@ -95,7 +95,7 @@ NORETURN void nlr_jump(void *val) {
         "ret                        \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/nlrxtensa.c
+++ b/py/nlrxtensa.c
@@ -74,7 +74,7 @@ NORETURN void nlr_jump(void *val) {
         "ret.n                      \n" // return
         :                           // output operands
         : "r" (top)                 // input operands
-        :                           // clobbered registers
+        : "memory"                  // clobbered registers
         );
 
     MP_UNREACHABLE

--- a/py/obj.c
+++ b/py/obj.c
@@ -119,7 +119,7 @@ void mp_obj_print_helper(const mp_print_t *print, mp_obj_t o_in, mp_print_kind_t
     if (type->print != NULL) {
         type->print((mp_print_t *)print, o_in, kind);
     } else {
-        mp_printf(print, "<%q>", type->name);
+        mp_printf(print, "<%q>", (qstr)type->name);
     }
 }
 


### PR DESCRIPTION
Needed for trezor/trezor-firmware#3337. Cherry-picks micropython/micropython#14126, there's also a workaround for suspected aarch64 gcc bug.