### PR TITLE
py/misc: use `__builtin_strcmp` to enable compile-time optimization

### DIFF
--- a/py/misc.h
+++ b/py/misc.h
@@ -299,7 +299,7 @@ typedef struct {
 inline __attribute__((always_inline)) const char *MP_COMPRESSED_ROM_TEXT(const char *msg) {
     // "genhdr/compressed.data.h" contains an invocation of the MP_MATCH_COMPRESSED macro for each compressed string.
     // The giant if(strcmp) tree is optimized by the compiler, which turns this into a direct return of the compressed data.
-    #define MP_MATCH_COMPRESSED(a, b) if (strcmp(msg, a) == 0) { return b; } else
+    #define MP_MATCH_COMPRESSED(a, b) if (__builtin_strcmp(msg, a) == 0) { return b; } else
 
     // It also contains a single invocation of the MP_COMPRESSED_DATA macro, we don't need that here.
     #define MP_COMPRESSED_DATA(x)


### PR DESCRIPTION
Otherwise, it seems that the compiler doesn't optimize the `strcmp` generated here:
https://github.com/dpgeorge/micropython/blob/154b4eb354d97c7c28253bdc5212b2e58ea6462e/py/misc.h#L286
Similar issue was reported in https://github.com/micropython/micropython/pull/7659#issuecomment-899479793.