### PR TITLE
py/obj: allow disabling traceback allocation

### DIFF
--- a/py/mpconfig.h
+++ b/py/mpconfig.h
@@ -1403,6 +1403,11 @@ typedef double mp_float_t;
 #define MICROPY_PY_SYS_TRACEBACKLIMIT (MICROPY_CONFIG_ROM_LEVEL_AT_LEAST_EVERYTHING)
 #endif
 
+// Whether to disable traceback allocation
+#ifndef MICROPY_PY_SYS_TRACEBACK_DISABLE
+#define MICROPY_PY_SYS_TRACEBACK_DISABLE 0
+#endif
+
 // Whether the sys module supports attribute delegation
 // This is enabled automatically when needed by other features
 #ifndef MICROPY_PY_SYS_ATTR_DELEGATION

--- a/py/obj.h
+++ b/py/obj.h
@@ -856,7 +856,11 @@ bool mp_obj_is_exception_type(mp_obj_t self_in);
 bool mp_obj_is_exception_instance(mp_obj_t self_in);
 bool mp_obj_exception_match(mp_obj_t exc, mp_const_obj_t exc_type);
 void mp_obj_exception_clear_traceback(mp_obj_t self_in);
+#if MICROPY_PY_SYS_TRACEBACK_DISABLE
+static inline void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qstr block) {}
+#else
 void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qstr block);
+#endif
 void mp_obj_exception_get_traceback(mp_obj_t self_in, size_t *n, size_t **values);
 mp_obj_t mp_obj_exception_get_value(mp_obj_t self_in);
 mp_obj_t mp_obj_exception_make_new(const mp_obj_type_t *type_in, size_t n_args, size_t n_kw, const mp_obj_t *args);

--- a/py/objexcept.c
+++ b/py/objexcept.c
@@ -569,6 +569,7 @@ void mp_obj_exception_clear_traceback(mp_obj_t self_in) {
     self->traceback_data = NULL;
 }
 
+#if !MICROPY_PY_SYS_TRACEBACK_DISABLE
 void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qstr block) {
     mp_obj_exception_t *self = get_native_exception(self_in);
 
@@ -631,6 +632,7 @@ void mp_obj_exception_add_traceback(mp_obj_t self_in, qstr file, size_t line, qs
     tb_data[1] = line;
     tb_data[2] = block;
 }
+#endif // !MICROPY_PY_SYS_TRACEBACK_DISABLE
 
 void mp_obj_exception_get_traceback(mp_obj_t self_in, size_t *n, size_t **values) {
     mp_obj_exception_t *self = get_native_exception(self_in);


### PR DESCRIPTION
Since the existing code handles `NULL` `traceback_data` correctly, it would be better to avoid heap allocation in builds that don't access traceback data.

Following https://github.com/trezor/trezor-firmware/issues/5526.

Will be used by https://github.com/trezor/trezor-firmware/pull/5745.