### PR TITLE
Backport fixes for compilation with GCC 15.1

### DIFF
--- a/py/emitinlinethumb.c
+++ b/py/emitinlinethumb.c
@@ -150,27 +150,27 @@ typedef struct _reg_name_t { byte reg;
                              byte name[3];
 } reg_name_t;
 STATIC const reg_name_t reg_name_table[] = {
-    {0, "r0\0"},
-    {1, "r1\0"},
-    {2, "r2\0"},
-    {3, "r3\0"},
-    {4, "r4\0"},
-    {5, "r5\0"},
-    {6, "r6\0"},
-    {7, "r7\0"},
-    {8, "r8\0"},
-    {9, "r9\0"},
-    {10, "r10"},
-    {11, "r11"},
-    {12, "r12"},
-    {13, "r13"},
-    {14, "r14"},
-    {15, "r15"},
-    {10, "sl\0"},
-    {11, "fp\0"},
-    {13, "sp\0"},
-    {14, "lr\0"},
-    {15, "pc\0"},
+    {0, {'r', '0' }},
+    {1, {'r', '1' }},
+    {2, {'r', '2' }},
+    {3, {'r', '3' }},
+    {4, {'r', '4' }},
+    {5, {'r', '5' }},
+    {6, {'r', '6' }},
+    {7, {'r', '7' }},
+    {8, {'r', '8' }},
+    {9, {'r', '9' }},
+    {10, {'r', '1', '0' }},
+    {11, {'r', '1', '1' }},
+    {12, {'r', '1', '2' }},
+    {13, {'r', '1', '3' }},
+    {14, {'r', '1', '4' }},
+    {15, {'r', '1', '5' }},
+    {10, {'s', 'l' }},
+    {11, {'f', 'p' }},
+    {13, {'s', 'p' }},
+    {14, {'l', 'r' }},
+    {15, {'p', 'c' }},
 };
 
 #define MAX_SPECIAL_REGISTER_NAME_LENGTH 7
@@ -368,20 +368,20 @@ typedef struct _cc_name_t { byte cc;
                             byte name[2];
 } cc_name_t;
 STATIC const cc_name_t cc_name_table[] = {
-    { ASM_THUMB_CC_EQ, "eq" },
-    { ASM_THUMB_CC_NE, "ne" },
-    { ASM_THUMB_CC_CS, "cs" },
-    { ASM_THUMB_CC_CC, "cc" },
-    { ASM_THUMB_CC_MI, "mi" },
-    { ASM_THUMB_CC_PL, "pl" },
-    { ASM_THUMB_CC_VS, "vs" },
-    { ASM_THUMB_CC_VC, "vc" },
-    { ASM_THUMB_CC_HI, "hi" },
-    { ASM_THUMB_CC_LS, "ls" },
-    { ASM_THUMB_CC_GE, "ge" },
-    { ASM_THUMB_CC_LT, "lt" },
-    { ASM_THUMB_CC_GT, "gt" },
-    { ASM_THUMB_CC_LE, "le" },
+    { ASM_THUMB_CC_EQ, { 'e', 'q' }},
+    { ASM_THUMB_CC_NE, { 'n', 'e' }},
+    { ASM_THUMB_CC_CS, { 'c', 's' }},
+    { ASM_THUMB_CC_CC, { 'c', 'c' }},
+    { ASM_THUMB_CC_MI, { 'm', 'i' }},
+    { ASM_THUMB_CC_PL, { 'p', 'l' }},
+    { ASM_THUMB_CC_VS, { 'v', 's' }},
+    { ASM_THUMB_CC_VC, { 'v', 'c' }},
+    { ASM_THUMB_CC_HI, { 'h', 'i' }},
+    { ASM_THUMB_CC_LS, { 'l', 's' }},
+    { ASM_THUMB_CC_GE, { 'g', 'e' }},
+    { ASM_THUMB_CC_LT, { 'l', 't' }},
+    { ASM_THUMB_CC_GT, { 'g', 't' }},
+    { ASM_THUMB_CC_LE, { 'l', 'e' }},
 };
 
 typedef struct _format_4_op_t { byte op;
@@ -389,21 +389,21 @@ typedef struct _format_4_op_t { byte op;
 } format_4_op_t;
 #define X(x) (((x) >> 4) & 0xff) // only need 1 byte to distinguish these ops
 STATIC const format_4_op_t format_4_op_table[] = {
-    { X(ASM_THUMB_FORMAT_4_EOR), "eor" },
-    { X(ASM_THUMB_FORMAT_4_LSL), "lsl" },
-    { X(ASM_THUMB_FORMAT_4_LSR), "lsr" },
-    { X(ASM_THUMB_FORMAT_4_ASR), "asr" },
-    { X(ASM_THUMB_FORMAT_4_ADC), "adc" },
-    { X(ASM_THUMB_FORMAT_4_SBC), "sbc" },
-    { X(ASM_THUMB_FORMAT_4_ROR), "ror" },
-    { X(ASM_THUMB_FORMAT_4_TST), "tst" },
-    { X(ASM_THUMB_FORMAT_4_NEG), "neg" },
-    { X(ASM_THUMB_FORMAT_4_CMP), "cmp" },
-    { X(ASM_THUMB_FORMAT_4_CMN), "cmn" },
-    { X(ASM_THUMB_FORMAT_4_ORR), "orr" },
-    { X(ASM_THUMB_FORMAT_4_MUL), "mul" },
-    { X(ASM_THUMB_FORMAT_4_BIC), "bic" },
-    { X(ASM_THUMB_FORMAT_4_MVN), "mvn" },
+    { X(ASM_THUMB_FORMAT_4_EOR), {'e', 'o', 'r' }},
+    { X(ASM_THUMB_FORMAT_4_LSL), {'l', 's', 'l' }},
+    { X(ASM_THUMB_FORMAT_4_LSR), {'l', 's', 'r' }},
+    { X(ASM_THUMB_FORMAT_4_ASR), {'a', 's', 'r' }},
+    { X(ASM_THUMB_FORMAT_4_ADC), {'a', 'd', 'c' }},
+    { X(ASM_THUMB_FORMAT_4_SBC), {'s', 'b', 'c' }},
+    { X(ASM_THUMB_FORMAT_4_ROR), {'r', 'o', 'r' }},
+    { X(ASM_THUMB_FORMAT_4_TST), {'t', 's', 't' }},
+    { X(ASM_THUMB_FORMAT_4_NEG), {'n', 'e', 'g' }},
+    { X(ASM_THUMB_FORMAT_4_CMP), {'c', 'm', 'p' }},
+    { X(ASM_THUMB_FORMAT_4_CMN), {'c', 'm', 'n' }},
+    { X(ASM_THUMB_FORMAT_4_ORR), {'o', 'r', 'r' }},
+    { X(ASM_THUMB_FORMAT_4_MUL), {'m', 'u', 'l' }},
+    { X(ASM_THUMB_FORMAT_4_BIC), {'b', 'i', 'c' }},
+    { X(ASM_THUMB_FORMAT_4_MVN), {'m', 'v', 'n' }},
 };
 #undef X
 
@@ -428,10 +428,10 @@ typedef struct _format_vfp_op_t {
     char name[3];
 } format_vfp_op_t;
 STATIC const format_vfp_op_t format_vfp_op_table[] = {
-    { 0x30, "add" },
-    { 0x34, "sub" },
-    { 0x20, "mul" },
-    { 0x80, "div" },
+    { 0x30, {'a', 'd', 'd' }},
+    { 0x34, {'s', 'u', 'b' }},
+    { 0x20, {'m', 'u', 'l' }},
+    { 0x80, {'d', 'i', 'v' }},
 };
 
 // shorthand alias for whether we allow ARMv7-M instructions

--- a/py/emitinlinextensa.c
+++ b/py/emitinlinextensa.c
@@ -115,50 +115,21 @@ STATIC bool emit_inline_xtensa_label(emit_inline_asm_t *emit, mp_uint_t label_nu
     return true;
 }
 
-typedef struct _reg_name_t { byte reg;
-                             byte name[3];
-} reg_name_t;
-STATIC const reg_name_t reg_name_table[] = {
-    {0, "a0\0"},
-    {1, "a1\0"},
-    {2, "a2\0"},
-    {3, "a3\0"},
-    {4, "a4\0"},
-    {5, "a5\0"},
-    {6, "a6\0"},
-    {7, "a7\0"},
-    {8, "a8\0"},
-    {9, "a9\0"},
-    {10, "a10"},
-    {11, "a11"},
-    {12, "a12"},
-    {13, "a13"},
-    {14, "a14"},
-    {15, "a15"},
+STATIC const qstr_short_t REGISTERS[16] = {
+    MP_QSTR_a0, MP_QSTR_a1, MP_QSTR_a2, MP_QSTR_a3, MP_QSTR_a4, MP_QSTR_a5, MP_QSTR_a6, MP_QSTR_a7,
+    MP_QSTR_a8, MP_QSTR_a9, MP_QSTR_a10, MP_QSTR_a11, MP_QSTR_a12, MP_QSTR_a13, MP_QSTR_a14, MP_QSTR_a15
 };
 
-// return empty string in case of error, so we can attempt to parse the string
-// without a special check if it was in fact a string
-STATIC const char *get_arg_str(mp_parse_node_t pn) {
-    if (MP_PARSE_NODE_IS_ID(pn)) {
-        qstr qst = MP_PARSE_NODE_LEAF_ARG(pn);
-        return qstr_str(qst);
-    } else {
-        return "";
-    }
-}
-
 STATIC mp_uint_t get_arg_reg(emit_inline_asm_t *emit, const char *op, mp_parse_node_t pn) {
-    const char *reg_str = get_arg_str(pn);
-    for (mp_uint_t i = 0; i < MP_ARRAY_SIZE(reg_name_table); i++) {
-        const reg_name_t *r = &reg_name_table[i];
-        if (reg_str[0] == r->name[0]
-            && reg_str[1] == r->name[1]
-            && reg_str[2] == r->name[2]
-            && (reg_str[2] == '\0' || reg_str[3] == '\0')) {
-            return r->reg;
+    if (MP_PARSE_NODE_IS_ID(pn)) {
+        qstr node_qstr = MP_PARSE_NODE_LEAF_ARG(pn);
+        for (size_t i = 0; i < MP_ARRAY_SIZE(REGISTERS); i++) {
+            if (node_qstr == REGISTERS[i]) {
+                return i;
+            }
         }
     }
+
     emit_inline_xtensa_error_exc(emit,
         mp_obj_new_exception_msg_varg(&mp_type_SyntaxError,
             MP_ERROR_TEXT("'%s' expects a register"), op));


### PR DESCRIPTION
Errors out on `-Wunterminated-string-initialization`. See also micropython/micropython#17269, micropython/micropython#16736.