### PR TITLE
emit: allow `mpy-cross` to exclude source lines' data

### DIFF
--- a/mpy-cross/main.c
+++ b/mpy-cross/main.c
@@ -44,6 +44,10 @@
 STATIC uint emit_opt = MP_EMIT_OPT_NONE;
 mp_uint_t mp_verbose_flag = 0;
 
+#if MICROPY_ENABLE_SOURCE_LINE
+static bool include_source_lines = true;
+#endif
+
 // Heap size of GC heap (if enabled)
 // Make it larger on a 64 bit machine, because pointers are larger.
 long heap_size = 1024 * 1024 * (sizeof(mp_uint_t) / 4);
@@ -126,6 +130,12 @@ STATIC int usage(char **argv) {
         "  heapsize=<n> -- set the heap size for the GC (default %ld)\n"
         , heap_size);
     impl_opts_cnt++;
+    #if MICROPY_ENABLE_SOURCE_LINE
+    printf(
+        "  source-lines    -- include source line numbers (default)\n"
+        "  no-source-lines -- exclude source line numbers\n");
+    impl_opts_cnt += 2;
+    #endif
 
     if (impl_opts_cnt == 0) {
         printf("  (none)\n");
@@ -149,6 +159,14 @@ STATIC void pre_process_options(int argc, char **argv) {
                     emit_opt = MP_EMIT_OPT_NATIVE_PYTHON;
                 } else if (strcmp(argv[a + 1], "emit=viper") == 0) {
                     emit_opt = MP_EMIT_OPT_VIPER;
+                #if MICROPY_ENABLE_SOURCE_LINE
+                } else if (strcmp(argv[a + 1], "source-lines") == 0) {
+                    // Allow excluding source lines for debug builds.
+                    include_source_lines = true;
+                } else if (strcmp(argv[a + 1], "no-source-lines") == 0) {
+                    // Allow excluding source lines for debug builds.
+                    include_source_lines = false;
+                #endif
                 #endif
                 } else if (strncmp(argv[a + 1], "heapsize=", sizeof("heapsize=") - 1) == 0) {
                     char *end;
@@ -199,6 +217,10 @@ MP_NOINLINE int main_(int argc, char **argv) {
     MP_STATE_VM(default_emit_opt) = emit_opt;
     #else
     (void)emit_opt;
+    #endif
+
+    #if MICROPY_ENABLE_SOURCE_LINE
+    MP_STATE_VM(include_source_lines) = include_source_lines;
     #endif
 
     // set default compiler configuration

--- a/py/emitbc.c
+++ b/py/emitbc.c
@@ -419,7 +419,7 @@ void mp_emit_bc_set_source_line(emit_t *emit, mp_uint_t source_line) {
         // If we compile with -O3, don't store line numbers.
         return;
     }
-    if (source_line > emit->last_source_line) {
+    if (MP_STATE_VM(include_source_lines) && source_line > emit->last_source_line) {
         mp_uint_t bytes_to_skip = emit->bytecode_offset - emit->last_source_line_offset;
         mp_uint_t lines_to_skip = source_line - emit->last_source_line;
         emit_write_code_info_bytes_lines(emit, bytes_to_skip, lines_to_skip);

--- a/py/mpstate.h
+++ b/py/mpstate.h
@@ -235,6 +235,9 @@ typedef struct _mp_state_vm_t {
     #if MICROPY_EMIT_NATIVE
     uint8_t default_emit_opt; // one of MP_EMIT_OPT_xxx
     #endif
+    #if MICROPY_ENABLE_SOURCE_LINE
+    bool include_source_lines;
+    #endif
     #endif
 
     // size of the emergency exception buf, if it's dynamically allocated

--- a/py/runtime.c
+++ b/py/runtime.c
@@ -99,6 +99,9 @@ void mp_init(void) {
     #if MICROPY_EMIT_NATIVE
     MP_STATE_VM(default_emit_opt) = MP_EMIT_OPT_NONE;
     #endif
+    #if MICROPY_ENABLE_SOURCE_LINE
+    MP_STATE_VM(include_source_lines) = true;
+    #endif
     #endif
 
     // init global module dict


### PR DESCRIPTION
This would allow having debug FW builds without source line data.

The new `emit_no_source_lines` flag is disabled by default, and is used only by `mpy-cross`.

Will be used by https://github.com/trezor/trezor-firmware/pull/6736 to resolve https://github.com/trezor/trezor-firmware/issues/6715.

Upstream PR: https://github.com/micropython/micropython/pull/19080